### PR TITLE
net5.0 に切り替える

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,7 +1,10 @@
-﻿using System.Net;
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace UdpBroadcast
 {

--- a/UdpBroadcast.csproj
+++ b/UdpBroadcast.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFramework>net5.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
net5.0 に切り替える
https://www.ipentec.com/document/csharp-compile-error-on-global-using-in-dot-net-5-down-grade-from-dot-net-6
